### PR TITLE
Remove transparency from backgrounds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# main
+- Do not make pop-ups and menus transparent.
+
 # Version 0.1.2 - 2023-08-08
 - Do not move around menu, toolbar and tabs.
 - Lower maximum allowed Thunderbird version to 118 to allow uploading to addons.thunderbird.net.

--- a/manifest.json
+++ b/manifest.json
@@ -51,8 +51,8 @@
             "tree_view_color": "CanvasText",
             "tree_view_bg": "Canvas",
 
-            "layout_background_0": "color-mix(in srgb, Canvas 60%, transparent)",
-            "layout_background_1": "color-mix(in srgb, Canvas 80%, transparent)"
+            "layout_background_0": "Canvas",
+            "layout_background_1": "Canvas"
         }
     },
     "theme_experiment": {


### PR DESCRIPTION
Turns out, the background colors are also used for menus and popups. And we don't want to have those be transparent.